### PR TITLE
Upgrade reason-apollo to 0.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bsdoc": "6.0.1-alpha",
     "husky": "^3.0.5",
     "lint-staged": "^9.4.0",
-    "reason-apollo": "^0.18.0",
+    "reason-apollo": "^0.20.0",
     "reason-react": ">=0.7.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@apollo/react-hooks": "^3.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "reason-apollo": "^0.18.0",
+    "reason-apollo": "^0.20.0",
     "reason-react": ">=0.7.0"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1808,10 +1808,10 @@ readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-reason-apollo@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/reason-apollo/-/reason-apollo-0.18.0.tgz#cc970da88de7ac603753eed68984c8492f0665c6"
-  integrity sha512-lw+IoIZ8qoX3iGOFFK//yMVC+Xmf+OcSyKkRgbBn0uG5GomLLMLiKRgjkhUsjAqJ4b3Se7H9JFnso5nL+GFEMA==
+reason-apollo@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/reason-apollo/-/reason-apollo-0.20.0.tgz#102e6047bfc37d9f30462799e7f813d17dd4758a"
+  integrity sha512-L0y1mCcViRX6yhdo9dUQAhuDazE1ZbMb3IPuBnlTvQffvecmtDfl0RQ+BCzoCJEP3u8nwb88z2JDoURnaFDSkQ==
   dependencies:
     apollo-cache-inmemory "^1.6.0"
     apollo-client "^2.6.3"


### PR DESCRIPTION
I may have been misunderstanding something, but it seems that master can't compile without upgrading `reason-apollo` to `0.20` so I thought I'd do that.

```
  159 │ let toQueryObj = result =>
  160 │   ApolloClient.{
  161 │     query: ApolloClient.gql(. result##query),
  162 │     variables: result##variables,
  163 │   };
  
  The record field query can't be found.
```