### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Tell github that .re and .rei files are Reason
+*.re linguist-language=Reason
+*.rei linguist-language=Reason


### PR DESCRIPTION
Add `.gitattributes` so this library show up as a `reason` repo rather than `c++` repo